### PR TITLE
Adding Smart Coding School as a Sponsor

### DIFF
--- a/_data/upcoming_contests.yml
+++ b/_data/upcoming_contests.yml
@@ -1,5 +1,6 @@
 - title: Spring 2019 MIHS Programming Contest
   img: /assets/contest_images/MI_Logo.jpg
+  cohost: Smart Coding School
   date: March 16th, 2019
   location: Mercer Island High School, WA
   link: /contests/spring-2019-mihs-programming-contest/

--- a/_posts/contests/2018-10-26-spring-2019-mihs-programming-contest.md
+++ b/_posts/contests/2018-10-26-spring-2019-mihs-programming-contest.md
@@ -15,7 +15,7 @@ contest_date: March 16th, 2019
 
 <h1>Registration</h1>
 
-<h1>Sign Up Here</h1 a href="https://teamscode.typeform.com/to/bnGcWl">
+<h1><a href="https://teamscode.typeform.com/to/bnGcWl">Sign Up Here</a></h1>
 
  *Registration is free.*
 

--- a/_posts/contests/2018-10-26-spring-2019-mihs-programming-contest.md
+++ b/_posts/contests/2018-10-26-spring-2019-mihs-programming-contest.md
@@ -7,6 +7,11 @@ contest_location_link: https://www.google.com/maps/place/Mercer+Island+High+Scho
 contest_date: March 16th, 2019
 ---
 
+<div style="float: right; margin-right: -140px; margin-left: 10px; text-align: center;">
+  <h1 style="text-align: left;"><b>Platinum Sponsors</b></h1>
+  <a href="http://www.smartcodingschool.com/"><img src="/assets/images/sponsor_smartcodingschool.png" alt="Smart Coding School" style="width: 250px; margin-right: 20px;"></a>
+</div>
+
 <h1>Registration</h1>
 
 Registration is now available. There is no fee to compete. If you wish to attend, [Sign Up Here](https://teamscode.typeform.com/to/bnGcWl).
@@ -89,5 +94,11 @@ _Note: These are guidelines, not rules. You may choose to sign up for either div
 # Documents #
 
 This pdf will describe how to read a txt file in Java, C#, C++, and Python, using a Mac or PC.
+
+# Sponsors
+
+## **Platinum Sponsor:** <a href="http://www.smartcodingschool.com/">Smart Coding School</a>
+
+<a href="http://www.smartcodingschool.com/"><img src="/assets/images/sponsor_smartcodingschool.png" alt="Smart Coding School" style="width: 250px; margin-right: 20px;"></a>
 
 <a href="/assets/docs/reading_input_files_packet.pdf">Reading Input Files</a>

--- a/_posts/contests/2018-10-26-spring-2019-mihs-programming-contest.md
+++ b/_posts/contests/2018-10-26-spring-2019-mihs-programming-contest.md
@@ -2,6 +2,7 @@
 layout: post-contest
 permalink: /contests/spring-2019-mihs-programming-contest/
 contest_title: Spring 2019 MIHS Programming Contest
+contest_cohost: Smart Coding School
 contest_location: Mercer Island High School
 contest_location_link: https://www.google.com/maps/place/Mercer+Island+High+School/@47.5719538,-122.2202913,17z/data=!4m12!1m6!3m5!1s0x54906bdae7961a9d:0x6e6caf34f523feb!2sMercer+Island+High+School!8m2!3d47.5719538!4d-122.2181026!3m4!1s0x54906bdae7961a9d:0x6e6caf34f523feb!8m2!3d47.5719538!4d-122.2181026
 contest_date: March 16th, 2019
@@ -14,7 +15,7 @@ contest_date: March 16th, 2019
 
 <h1>Registration</h1>
 
-Registration is now available. There is no fee to compete. If you wish to attend, [Sign Up Here](https://teamscode.typeform.com/to/bnGcWl).
+[Sign Up Here](https://teamscode.typeform.com/to/bnGcWl). *Registration is free.*
 
 If you accidentally registered for the competition, or are unable to attend, please de-register [here](https://teamscode.typeform.com/to/XTYQIh).
 
@@ -95,10 +96,10 @@ _Note: These are guidelines, not rules. You may choose to sign up for either div
 
 This pdf will describe how to read a txt file in Java, C#, C++, and Python, using a Mac or PC.
 
+<a href="/assets/docs/reading_input_files_packet.pdf">Reading Input Files</a>
+
 # Sponsors
 
 ## **Platinum Sponsor:** <a href="http://www.smartcodingschool.com/">Smart Coding School</a>
 
 <a href="http://www.smartcodingschool.com/"><img src="/assets/images/sponsor_smartcodingschool.png" alt="Smart Coding School" style="width: 250px; margin-right: 20px;"></a>
-
-<a href="/assets/docs/reading_input_files_packet.pdf">Reading Input Files</a>

--- a/_posts/contests/2018-10-26-spring-2019-mihs-programming-contest.md
+++ b/_posts/contests/2018-10-26-spring-2019-mihs-programming-contest.md
@@ -15,7 +15,9 @@ contest_date: March 16th, 2019
 
 <h1>Registration</h1>
 
-[Sign Up Here](https://teamscode.typeform.com/to/bnGcWl). *Registration is free.*
+<h1>[Sign Up Here](https://teamscode.typeform.com/to/bnGcWl).<h1>
+
+ *Registration is free.*
 
 If you accidentally registered for the competition, or are unable to attend, please de-register [here](https://teamscode.typeform.com/to/XTYQIh).
 

--- a/_posts/contests/2018-10-26-spring-2019-mihs-programming-contest.md
+++ b/_posts/contests/2018-10-26-spring-2019-mihs-programming-contest.md
@@ -15,7 +15,7 @@ contest_date: March 16th, 2019
 
 <h1>Registration</h1>
 
-<h1>[Sign Up Here](https://teamscode.typeform.com/to/bnGcWl).<h1>
+<h1>Sign Up Here</h1 a href="https://teamscode.typeform.com/to/bnGcWl">
 
  *Registration is free.*
 

--- a/_posts/contests/2018-10-26-spring-2019-mihs-programming-contest.md
+++ b/_posts/contests/2018-10-26-spring-2019-mihs-programming-contest.md
@@ -105,3 +105,7 @@ This pdf will describe how to read a txt file in Java, C#, C++, and Python, usin
 ## **Platinum Sponsor:** <a href="http://www.smartcodingschool.com/">Smart Coding School</a>
 
 <a href="http://www.smartcodingschool.com/"><img src="/assets/images/sponsor_smartcodingschool.png" alt="Smart Coding School" style="width: 250px; margin-right: 20px;"></a>
+
+## About <u>Smart Coding School</u>:
+Smart Coding School is a computer science education school established in March 2016. We develop computer science & engineering curriculum and offer courses for middle school and high school students (12 ~ 18 years old), and mainly provide Java Programming, data structures and algorithms, computer science A AP Test Prep and USA Computing Olympiad (USACO) training courses. In 2017 Computer Science A AP Test, there are 95% students receiving 5 out of 5 scores. Many students successfully got into Platinum, Gold and Silver level in USA Computing Olympiad competition. In the local coding competitions, our students took 2nd place in the advanced level and 1st place in the intermediate level.
+Smart Coding School is powered by passionate software engineers from local top hi-tech companies such as Amazon, Microsoft. We believe that early computer science education can make a big difference for students. Our passion is to inspire kids & teens to see things differently from engineering perspectives and to believe that they can make a big impact through technology. Smart Coding School is all about students and prepare students for the future with technology. 


### PR DESCRIPTION
I took the appropriate code from the Fall 2018 MIHS Post and added it to the Spring 2019 Post. Specifically, I copied the division for the sponsors which floats on the left and removed all entries except Smart Coding School; and the sponsors division at the very bottom.