### PR TITLE
Fix font rendering issue on systems that don't have Microsoft proprietary fonts

### DIFF
--- a/_sass/includes/_header.scss
+++ b/_sass/includes/_header.scss
@@ -41,7 +41,7 @@
   .header-menu {
     
     float: right;
-    font-family: Verdana;
+    font-family: 'Verdana', 'Roboto', 'Arial';
     color: #444444;
 
     .header-menu-item {

--- a/_sass/pages/_blog.scss
+++ b/_sass/pages/_blog.scss
@@ -14,7 +14,7 @@
         color: $index-header-fnt-color;
         vertical-align: top;
         text-align: center;
-        font-family: Verdana;
+        font-family: 'Verdana', 'Roboto', 'Arial';
         color: white;
         line-height: 1.4;
         padding: 0px;

--- a/_sass/pages/_contact.scss
+++ b/_sass/pages/_contact.scss
@@ -15,7 +15,7 @@
     width: 50%;
     font-size: 24px;
     font-weight: 400;
-    font-family: 'Verdana';
+    font-family: 'Verdana', 'Roboto', 'Arial';
   }
 
   .contact-input-section {

--- a/_sass/pages/_contests.scss
+++ b/_sass/pages/_contests.scss
@@ -25,7 +25,7 @@
   text-decoration: none;
   display: inline-block;
   font-size: 16px;
-  font-family: Verdana;
+  font-family: 'Verdana', 'Roboto', 'Arial';
   font-weight: bold;
   margin-right: 5px;
   margin-left: 5px;

--- a/_sass/pages/_index.scss
+++ b/_sass/pages/_index.scss
@@ -14,7 +14,7 @@
     color: $index-header-fnt-color;
     vertical-align: top;
     text-align: center;
-    font-family: Verdana;
+    font-family: 'Verdana', 'Roboto', 'Arial';
     color: white;
     line-height: 1.4;
     
@@ -39,7 +39,7 @@
       text-decoration: none;
       display: inline-block;
       font-size: 16px;
-      font-family: Verdana;
+      font-family: 'Verdana', 'Roboto', 'Arial';
       font-weight: bold;
       margin-right: 5px;
       margin-left: 5px;
@@ -80,7 +80,7 @@
   margin: auto;
   text-align: center;
   font-size: 24px;
-  font-family: 'Verdana';
+  font-family: 'Verdana', 'Roboto', 'Arial';
   font-weight: bold;
 }
 
@@ -106,19 +106,19 @@
 
   .problem-item-title {
     font-size: 14px;
-    font-family: 'Verdana';
+    font-family: 'Verdana', 'Roboto', 'Arial';
   }
   .problem-item-techniques {
     margin-top:1px;
     font-style: italic;
     font-size: 12px;
-    font-family: 'Verdana';
+    font-family: 'Verdana', 'Roboto', 'Arial';
   }
 
 }
 
 .apply-widget {
-  font-family:"Verdana";
+  font-family:'Verdana', 'Roboto', 'Arial';
   font-size:20px;
   line-height: 1.4;
   margin-top: -10px;
@@ -130,14 +130,14 @@
   padding: 40px 0;
 
   .widget-header {
-    font-family:"Verdana";
+    font-family:'Verdana', 'Roboto', 'Arial';
     font-size:35px;
     font-weight:bold;
     margin-bottom:40px;
   }
 
   .widget-body {
-    font-family:"Georgia";
+    font-family:'Georgia', 'Roboto', 'Arial';
     font-size:18px;
     line-height:1.6;
     margin-bottom: 40px;

--- a/_sass/pages/_lessons.scss
+++ b/_sass/pages/_lessons.scss
@@ -58,14 +58,14 @@
   padding: 40px 0;
 
   .lesson-header {
-    font-family:"Verdana";
+    font-family:'Verdana', 'Roboto', 'Arial';
     font-size:35px;
     font-weight:bold;
     margin-bottom:40px;
   }
 
   .lesson-body {
-    font-family:"Georgia";
+    font-family:'Georgia', 'Roboto', 'Arial';
     font-size:18px;
     line-height:1.6;
     //margin-bottom: 40px;

--- a/_sass/pages/_press.scss
+++ b/_sass/pages/_press.scss
@@ -26,14 +26,14 @@
   .heading {
     font-size: 24px;
     font-weight: 400;
-    font-family: 'Verdana';
+    font-family: 'Verdana', 'Roboto', 'Arial';
     margin-bottom:20px;
   }
 
   .heading-link {
     font-size: 30px;
     font-weight: 400;
-    font-family: 'Verdana';
+    font-family: 'Verdana', 'Roboto', 'Arial';
     margin-bottom:20px;
     color: #5176E0;
   }

--- a/_sass/theme/_typography.scss
+++ b/_sass/theme/_typography.scss
@@ -22,34 +22,34 @@ a {
 
 .h1 {
   font-size: 50px;
-  font-family: 'Verdana';
+  font-family: 'Verdana', 'Roboto', 'Arial';
   line-height: 1.4;
 }
 
 .h2 {
   font-size: 24px;
   font-weight: 400;
-  font-family: 'Verdana';
+  font-family: 'Verdana', 'Roboto', 'Arial';
 }
 
 .h3 {
   font-size: 21px;
   font-weight: 400;
-  font-family: 'Verdana';
+  font-family: 'Verdana', 'Roboto', 'Arial';
 }
 
 .h4 {
   font-size: 18px;
   font-weight: 400;
   line-height: 26px;
-  font-family: 'Verdana';
+  font-family: 'Verdana', 'Roboto', 'Arial';
 }
 
 .p {
   font-size: 15px;
   line-height: 1.6;
   max-width: 700px;
-  font-family: 'Verdana';
+  font-family: 'Verdana', 'Roboto', 'Arial';
 }
 
 .a {


### PR DESCRIPTION
Add font alternatives to Verdana and Georgia, which may not be available on Linux and Chromebook. These fonts also don't have automatic alternatives, resulting in an ugly default font being used.

Verdana and Georgia will still be preferred whenever available.

Screenshots are taken on Fedora 33 Workstation, Google Chrome v89.0.4389
## Before
![before](https://user-images.githubusercontent.com/30813603/110192893-b5710d80-7de5-11eb-94cb-e17baf910960.png)

## After
![after](https://user-images.githubusercontent.com/30813603/110192899-ba35c180-7de5-11eb-9a8f-ec1478a1702c.png)
